### PR TITLE
Fix tramvai create

### DIFF
--- a/tools/create/bin/create.js
+++ b/tools/create/bin/create.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+require('child_process').spawnSync('tramvai', ['new'].concat(process.argv.slice(2)), {
+  stdio: 'inherit'
+});

--- a/tools/create/bin/create.sh
+++ b/tools/create/bin/create.sh
@@ -1,1 +1,0 @@
-tramvai new "$@"

--- a/tools/create/package.json
+++ b/tools/create/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0-stub",
   "description": "",
   "main": "lib/index.js",
-  "bin": "./bin/create.sh",
+  "bin": "./bin/create.js",
   "files": [
     "bin"
   ],


### PR DESCRIPTION
From the old repository I found that PRs are not accepted, but the create command is not working correctly:

```shell
yarn create @tramvai@latest app

...

/Users/eolme/.yarn/berry/cache/@tramvai-create-npm-2.160.1-3a7600b682-8.zip/node_modules/@tramvai/create/bin/create.sh:1
tramvai new "$@"
        ^^^

SyntaxError: Unexpected token 'new'
    at internalCompileFunction (node:internal/vm:73:18)
    at wrapSafe (node:internal/modules/cjs/loader:1153:20)
    at Module._compile (node:internal/modules/cjs/loader:1205:27)
    at Module._extensions..js (node:internal/modules/cjs/loader:1295:10)
    at require$$0.Module._extensions..js (/private/var/folders/05/84wr2ckj1jvb3v32xsc6lnh80000gn/T/xfs-ffc84398/dlx-10710/.pnp.cjs:25811:33)
    at Module.load (node:internal/modules/cjs/loader:1091:32)
    at Module._load (node:internal/modules/cjs/loader:938:12)
    at require$$0.Module._load (/private/var/folders/05/84wr2ckj1jvb3v32xsc6lnh80000gn/T/xfs-ffc84398/dlx-10710/.pnp.cjs:25656:31)
    at cjsLoader (node:internal/modules/esm/translators:284:17)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:234:7)

```

Because of the missing shebang, the script is interpreted as js by default, so I propose a more cross-platform non-shell solution.