### PR TITLE
fix(storybook-addon): use HTTPS repository metadata

### DIFF
--- a/packages/tramvai/storybook-addon/package.json
+++ b/packages/tramvai/storybook-addon/package.json
@@ -10,7 +10,7 @@
   "sideEffects": false,
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/tramvaijs/tramvai.git"
+    "url": "git+https://github.com/tramvaijs/tramvai.git"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Updates the `@tramvai/storybook-addon` package metadata to use the public HTTPS GitHub repository URL instead of the SSH URL.

This makes the npm `repository.url` metadata usable in read-only/sandboxed environments without requiring SSH key configuration.

Bounty: https://github.com/charles-openclaw/charles-microbounties/issues/1939

Validation:
- Parsed `packages/tramvai/storybook-addon/package.json` as JSON after the change.
- Verified the only source change is `git+ssh://git@github.com/tramvaijs/tramvai.git` -> `git+https://github.com/tramvaijs/tramvai.git`.
